### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"         : "6.c",
     "name"         : "Bailador::Template::Mojo::Extended",
+    "license"      : "Artistic-2.0",
     "version"      : "2.001001",
     "description"  : "Extra features on top of the default ::Mojo renderer for Bailador",
     "depends"      : [


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license